### PR TITLE
[TRB-37815]: Added doc.go file with additional documentation/links for pkg.go.dev

### DIFF
--- a/api/v1alpha1/doc.go
+++ b/api/v1alpha1/doc.go
@@ -1,0 +1,34 @@
+// Copyright 2023 Turbonomic
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package turbo-policy contains Kubernetes CustomResourceDefinitions for generating Turbonomic policies. These CustomResources allow
+application owners to declarativly configure policies in a Kubernetes cluster moniroted bu Turbo to allow for easy configuration
+of Turbonomic policies. This permits application owners accustomed to working with Kubernetes resources to define Turbo policies
+as Kubernetes resources, as opposed to using the UI (to which they may not have access).
+
+# SLO Horizontal Scaling Policies
+
+For more information SLO Horizontal Scaling Policies see the [official documentation/https://www.ibm.com/docs/en/tarm/latest?topic=service-kubernetes-policies#policy_defaults_Service_K8s__CRK8s__title__1]
+
+# Vertical Scaling Policies
+
+For more infomation about Vertical Scaling Policies, see the [official documentation/https://www.ibm.com/docs/en/tarm/latest?topic=spec-container-policies]
+
+# Examples
+
+Sample policy and policy binding CustomResources can be found [here/https://github.com/turbonomic/turbo-policy/tree/main/config/samples]
+
+*/
+package v1alpha1

--- a/api/v1alpha1/doc.go
+++ b/api/v1alpha1/doc.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Turbonomic
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -29,6 +29,5 @@ For more infomation about Vertical Scaling Policies, see the [official documenta
 # Examples
 
 Sample policy and policy binding CustomResources can be found [here/https://github.com/turbonomic/turbo-policy/tree/main/config/samples]
-
 */
 package v1alpha1


### PR DESCRIPTION
# Intent

Added `doc.go` file with links to the official documentation. 

# Background

The [documentation section](https://pkg.go.dev/github.com/turbonomic/turbo-policy#section-documentation) for the `turbo-policy` repo on the [pkg.go.dev](https://pkg.go.dev) site is currently empty, as can been seen in the screenshot below.

![Screenshot 2023-08-29 at 1 01 45 PM](https://github.com/turbonomic/turbo-policy/assets/97479009/e0903c38-12e5-46da-8b3e-c05826c5c89d)
