### PR TITLE
[TRB-40910] Change the default max replicas to 10

### DIFF
--- a/api/v1alpha1/slohorizontalscale_types.go
+++ b/api/v1alpha1/slohorizontalscale_types.go
@@ -24,15 +24,15 @@ import (
 type SLOHorizontalScaleSpec struct {
 	// The minimum number of replicas of a service
 	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=10000
+	// +kubebuilder:validation:Maximum=10
 	// +kubebuilder:default:=1
 	// +optional
 	MinReplicas *int32 `json:"minReplicas,omitempty"`
 
 	// The maximum number of replicas of a service
 	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=10000
-	// +kubebuilder:default:=10000
+	// +kubebuilder:validation:Maximum=10
+	// +kubebuilder:default:=10
 	// +optional
 	MaxReplicas *int32 `json:"maxReplicas,omitempty"`
 

--- a/config/crd/bases/policy.turbonomic.io_slohorizontalscales.yaml
+++ b/config/crd/bases/policy.turbonomic.io_slohorizontalscales.yaml
@@ -69,17 +69,17 @@ spec:
                     type: string
                 type: object
               maxReplicas:
-                default: 10000
+                default: 10
                 description: The maximum number of replicas of a service
                 format: int32
-                maximum: 10000
+                maximum: 10
                 minimum: 1
                 type: integer
               minReplicas:
                 default: 1
                 description: The minimum number of replicas of a service
                 format: int32
-                maximum: 10000
+                maximum: 10
                 minimum: 1
                 type: integer
               objectives:


### PR DESCRIPTION
Currently the default max replicas of a service is 10000, which is not safe in production. We should set a conservative limit to 10.

I will add the change needed in kubeturbo and XL following this.